### PR TITLE
throw explicit err when the season is not found

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -46,7 +46,7 @@ class GamesController < ApplicationController
 
   def validate_info_params
     param! :season, String,
-           required: true, transform: ->(sn) { Season.find_by(short_name: sn) }
+           required: true, transform: ->(sn) { find_season sn }
     param! :start_date, DateTime,
            required: true, transform: :beginning_of_day,
            default: -> { Time.zone.now }
@@ -58,6 +58,12 @@ class GamesController < ApplicationController
     { current: collection.current_page, per_page: collection.per_page,
       total: collection.total_entries
     }
+  end
+
+  def find_season(short_name)
+    season = Season.find_by short_name: short_name
+    fail Errors::NoSeasonFoundError.new(nil, short_name, nil) if season.nil?
+    season
   end
 
   def parse_teams_from_params

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -37,7 +37,9 @@ module Errors
 
     def build_msg(name, short_name, league)
       league_str = (league.nil?) ? 'nil' : league.abbr
-      "Season(name: #{name}, short_name: #{short_name}, league: #{league_str}) does not exist"
+      name_str = name || 'nil'
+      short_name_str = short_name || 'nil'
+      "Season(name: #{name_str}, short_name: #{short_name_str}, league: #{league_str}) does not exist"
     end
   end
 end


### PR DESCRIPTION
closes #43

now the error in the console will be an explicit NoSeasonError,
which should at least indicate that you have a missing season.
the loading icon will still spin, but i'm going to live with that
for now. handling errors on the UI is something i haven't touched
for reasons
